### PR TITLE
Refactor SMTP handling to avoid OAuth usage

### DIFF
--- a/frappe_email_send_override/overrides/email_account.py
+++ b/frappe_email_send_override/overrides/email_account.py
@@ -19,7 +19,7 @@ class EmailAccountOverride(EmailAccount):
                 raise_exception=raise_exception,
             )
 
-        use_oauth= cint(not self.custom_outgoing_server_username and not self.custom_outgoing_server_password)
+        use_oauth = cint(not self.custom_outgoing_server_username and not self.custom_outgoing_server_password)
         return {
             "email_account": self.name,
             "server": self.smtp_server,

--- a/frappe_email_send_override/overrides/email_account.py
+++ b/frappe_email_send_override/overrides/email_account.py
@@ -19,6 +19,7 @@ class EmailAccountOverride(EmailAccount):
                 raise_exception=raise_exception,
             )
 
+        use_oauth= cint(not self.custom_outgoing_server_username and not self.custom_outgoing_server_password)
         return {
             "email_account": self.name,
             "server": self.smtp_server,
@@ -27,6 +28,6 @@ class EmailAccountOverride(EmailAccount):
             "password": password,
             "use_ssl": cint(self.use_ssl_for_outgoing),
             "use_tls": cint(self.use_tls),
-            "use_oauth": self.auth_method == "OAuth",
+            "use_oauth": use_oauth,
             "access_token": (oauth_token.get_password("access_token") if oauth_token else None),
         }


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

This pull request updates the logic for determining when to use OAuth authentication in the `sendmail_config` method of `email_account.py`. Instead of relying on the `auth_method` field, it now checks if both `custom_outgoing_server_username` and `custom_outgoing_server_password` are not set.

Authentication logic update:

* Changed the calculation of `use_oauth` to be true when both `custom_outgoing_server_username` and `custom_outgoing_server_password` are not set, instead of checking if `auth_method` is `"OAuth"`. (`frappe_email_send_override/overrides/email_account.py`) 

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> QA List

<!-- Add the QA list that needs to be done after PR merge -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->
